### PR TITLE
Delay licensing API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Due to the fact that it is impossible to automate the send out of the login info
 
 ### API requests quota
 
-In order to retrieve information about licenses of each user, there are multiple API requests performed. This can result in hitting the maximum limit of allowed calls per 100 seconds. In order to avoid it, `Gman` waits after every Enterprise Licensing API request for 0.6 second. This delay can be changed by starting the application with specified flag `-throttle-requests <value>`, where value designates the waiting time in seconds. 
+In order to retrieve information about licenses of each user, there are multiple API requests performed. This can result in hitting the maximum limit of allowed calls per 100 seconds. In order to avoid it, `Gman` waits after every Enterprise Licensing API request for 0.5 second. This delay can be changed by starting the application with specified flag `-throttle-requests <value>`, where value designates the waiting time in seconds. 
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
     - [Confirming synchronization](#confirming-synchronization)
   - [Limitations](#limitations)
     - [Sending the login info email to the new users](#sending-the-login-info-email-to-the-new-users)
+    - [API requests quota](#api-requests-quota)
   - [Changelog](#changelog)
 <!-- /TOC -->
 
@@ -271,6 +272,10 @@ Due to the fact that it is impossible to automate the send out of the login info
 
 - manually send the login information email from admin console via _RESET PASSWORD_ option (follow instructions on [this official Google documentation](https://support.google.com/a/answer/33319?hl=en))
 - set up a password recovery for users (follow [this official Google documentation](https://support.google.com/a/answer/33382?p=accnt_recovery_users&visit_id=637279854011127407-389630162&rd=1&hl=en) to perform it). This requires the `recovery_email` field to be set for the users. Hence, in the onboarding message the new users ought to be informed about their new GSuite email address and that on the first login, the _Forgot password?_ option should be chosen, so the verification code can be sent to to the private recovery email. 
+
+### API requests quota
+
+In order to retrieve information about licenses of each user, there are multiple API requests performed. This can result in hitting the maximum limit of allowed calls per 100 seconds. In order to avoid it, `Gman` waits after every Enterprise Licensing API request for 0.5 second. This delay can be changed by starting the application with specified flag `-throttle-requests <value>`, where value designates the waiting time in seconds. 
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Due to the fact that it is impossible to automate the send out of the login info
 
 ### API requests quota
 
-In order to retrieve information about licenses of each user, there are multiple API requests performed. This can result in hitting the maximum limit of allowed calls per 100 seconds. In order to avoid it, `Gman` waits after every Enterprise Licensing API request for 0.5 second. This delay can be changed by starting the application with specified flag `-throttle-requests <value>`, where value designates the waiting time in seconds. 
+In order to retrieve information about licenses of each user, there are multiple API requests performed. This can result in hitting the maximum limit of allowed calls per 100 seconds. In order to avoid it, `Gman` waits after every Enterprise Licensing API request for 0.6 second. This delay can be changed by starting the application with specified flag `-throttle-requests <value>`, where value designates the waiting time in seconds. 
 
 ## Changelog
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 		exportMode            = false
 		clientSecretFile      = ""
 		impersonatedUserEmail = ""
+		throttleRequests      = 0.6
 	)
 
 	flag.StringVar(&configFile, "config", configFile, "path to the config.yaml")
@@ -40,6 +41,7 @@ func main() {
 	flag.BoolVar(&confirm, "confirm", confirm, "must be set to actually perform any changes")
 	flag.BoolVar(&validate, "validate", validate, "validate the given configuration and then exit; does not need API key and impersonated email")
 	flag.BoolVar(&exportMode, "export", exportMode, "export the state and update the config file (-config flag)")
+	flag.Float64Var(&throttleRequests, "throttle-requests", throttleRequests, "the delay between Enterprise Licensing API requests expressed in seconds")
 
 	flag.Parse()
 
@@ -124,7 +126,7 @@ func main() {
 	if exportMode {
 		log.Printf("► Exporting organization %s…", cfg.Organization)
 
-		newConfig, err := export.ExportConfiguration(ctx, cfg.Organization, srv, grSrv, licSrv)
+		newConfig, err := export.ExportConfiguration(ctx, cfg.Organization, srv, grSrv, licSrv, throttleRequests)
 		if err != nil {
 			log.Fatalf("⚠ Failed to export %v.", err)
 		}
@@ -138,7 +140,7 @@ func main() {
 
 	log.Printf("► Updating organization %s…", cfg.Organization)
 
-	err = sync.SyncConfiguration(ctx, cfg, srv, grSrv, licSrv, confirm)
+	err = sync.SyncConfiguration(ctx, cfg, srv, grSrv, licSrv, confirm, throttleRequests)
 	if err != nil {
 		log.Fatalf("⚠ Failed to sync state: %v.", err)
 	}

--- a/main.go
+++ b/main.go
@@ -119,14 +119,9 @@ func main() {
 		log.Fatalf("⚠ Failed to create GSuite Groupssettings API client: %v", err)
 	}
 
-	licnsSrv, err := glib.NewLicensingService(clientSecretFile, impersonatedUserEmail)
+	licSrv, err := glib.NewLicensingService(clientSecretFile, impersonatedUserEmail, throttleRequests)
 	if err != nil {
 		log.Fatalf("⚠ Failed to create GSuite Licensing API client: %v", err)
-	}
-
-	licSrv := glib.LicensingService{
-		Service:          licnsSrv,
-		ThrottleRequests: throttleRequests,
 	}
 
 	if exportMode {

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/licensing/v1"
 )
 
-func ExportConfiguration(ctx context.Context, organization string, clientService *admin.Service, groupService *groupssettings.Service, licensingService *licensing.Service) (*config.Config, error) {
+func ExportConfiguration(ctx context.Context, organization string, clientService *admin.Service, groupService *groupssettings.Service, licensingService *licensing.Service, throttleRequests float64) (*config.Config, error) {
 	cfg := &config.Config{
 		Organization: organization,
 	}
@@ -21,7 +21,7 @@ func ExportConfiguration(ctx context.Context, organization string, clientService
 		return cfg, fmt.Errorf("org units: %v", err)
 	}
 
-	if err := exportUsers(ctx, clientService, licensingService, cfg); err != nil {
+	if err := exportUsers(ctx, clientService, licensingService, cfg, throttleRequests); err != nil {
 		return cfg, fmt.Errorf("users: %v", err)
 	}
 
@@ -32,7 +32,7 @@ func ExportConfiguration(ctx context.Context, organization string, clientService
 	return cfg, nil
 }
 
-func exportUsers(ctx context.Context, clientService *admin.Service, licensingService *licensing.Service, cfg *config.Config) error {
+func exportUsers(ctx context.Context, clientService *admin.Service, licensingService *licensing.Service, cfg *config.Config, throttleRequests float64) error {
 	log.Println("⇄ Exporting users from GSuite...")
 	// get the users array
 	users, err := glib.GetListOfUsers(*clientService)
@@ -46,7 +46,7 @@ func exportUsers(ctx context.Context, clientService *admin.Service, licensingSer
 	} else {
 		for _, u := range users {
 			// get user licenses
-			userLicenses, err := glib.GetUserLicenses(licensingService, u.PrimaryEmail)
+			userLicenses, err := glib.GetUserLicenses(licensingService, u.PrimaryEmail, throttleRequests)
 			if err != nil {
 				return err
 			}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -11,7 +11,7 @@ import (
 	groupssettings "google.golang.org/api/groupssettings/v1"
 )
 
-func ExportConfiguration(ctx context.Context, organization string, clientService *admin.Service, groupService *groupssettings.Service, licensingService glib.LicensingService) (*config.Config, error) {
+func ExportConfiguration(ctx context.Context, organization string, clientService *admin.Service, groupService *groupssettings.Service, licensingService *glib.LicensingService) (*config.Config, error) {
 	cfg := &config.Config{
 		Organization: organization,
 	}
@@ -31,7 +31,7 @@ func ExportConfiguration(ctx context.Context, organization string, clientService
 	return cfg, nil
 }
 
-func exportUsers(ctx context.Context, clientService *admin.Service, licensingService glib.LicensingService, cfg *config.Config) error {
+func exportUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config) error {
 	log.Println("⇄ Exporting users from GSuite...")
 	// get the users array
 	users, err := glib.GetListOfUsers(*clientService)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/api/groupssettings/v1"
 )
 
-func SyncConfiguration(ctx context.Context, cfg *config.Config, clientService *admin.Service, groupService *groupssettings.Service, licensingService glib.LicensingService, confirm bool) error {
+func SyncConfiguration(ctx context.Context, cfg *config.Config, clientService *admin.Service, groupService *groupssettings.Service, licensingService *glib.LicensingService, confirm bool) error {
 
 	if err := SyncOrgUnits(ctx, clientService, cfg, confirm); err != nil {
 		return fmt.Errorf("failed to sync org units: %v", err)
@@ -27,7 +27,7 @@ func SyncConfiguration(ctx context.Context, cfg *config.Config, clientService *a
 	return nil
 }
 
-func SyncUsers(ctx context.Context, clientService *admin.Service, licensingService glib.LicensingService, cfg *config.Config, confirm bool) error {
+func SyncUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config, confirm bool) error {
 	var (
 		usersToDelete []*admin.User
 		usersToCreate []config.UserConfig


### PR DESCRIPTION
This PR introduces a delay after performing an Enterprise License Manager API call. It is needed due to hitting the limits of the quota of allowed requests per 100 seconds. 
The delay time can be changed by a new flag `throttle-requests`. 