### PR TITLE
Add possibility to divide config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ For more detailed information, see [the official Google documentation](https://d
 
 Moreover, to access the extended settings of the groups, the **Groups Settings API** must be enabled (see [the official documentation](https://developers.google.com/admin-sdk/groups-settings/prerequisites#prereqs-enableapis)). To manage user licenses the **Enterprise License Manager API** has to be activated too (see [the official documentation](https://developers.google.com/admin-sdk/licensing/v1/how-tos/prerequisites#api-setup-steps)).
 
-
 ### Service account 
 
 To authorize and to perform the operations on behalf of *Gman* a Service Account is required. 
@@ -101,9 +100,7 @@ The configuration can be splitted as well in different files:
 - groups config file, specified by flag `-groups-config <value.yaml>`
 - organizational units config file, specified by flag `-orgunits-config <value.yaml>`
 
-Splitting the configuration allows as well to use *Gman* to manage only users, groups or organizational units, depending on the need. In that case, the scopes of service account can be reduced: 
-
-
+Splitting the configuration allows as well to use *Gman* to manage only users, groups or organizational units, depending on the need. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,19 @@ All configuration of the users happens in a YAML file. See the [configuration do
 This file must be created beforehand with the minimal configuration, i.e. organization name specified. 
 In order to get the initial config of the users that are already in place in your Organizaiton, run *Gman* with `-export` flag specified, so the depicted on your side YAML can be populated. 
 
-There are two ways to specify the path to the configuration YAML file:
+There are two ways to specify the path to the general configuration YAML file:
 
 - set up environmental variable: `GMAN_CONFIG_FILE=<VALUE>` 
 - start the application with specified flag `-config <value>`
+
+The configuration can be splitted as well in different files: 
+
+- users config file, specified by flag `-users-config <value.yaml>`
+- groups config file, specified by flag `-groups-config <value.yaml>`
+- organizational units config file, specified by flag `-orgunits-config <value.yaml>`
+
+Splitting the configuration allows as well to use *Gman* to manage only users, groups or organizational units, depending on the need. In that case, the scopes of service account can be reduced: 
+
 
 
 ## Usage

--- a/main.go
+++ b/main.go
@@ -37,11 +37,11 @@ func main() {
 		impersonatedUserEmail = ""
 		throttleRequests      = 500 * time.Millisecond
 
-		splittedConfig = false
-		userCfg        *config.Config
-		groupCfg       *config.Config
-		orgunitsCfg    *config.Config
-		err            error
+		splitConfig = false
+		userCfg     *config.Config
+		groupCfg    *config.Config
+		orgunitsCfg *config.Config
+		err         error
 	)
 
 	flag.StringVar(&configFile, "config", configFile, "path to the config.yaml that manages whole organization; cannot be used together with separated config files for users/groups/organizational units")
@@ -63,14 +63,13 @@ func main() {
 		return
 	}
 
-	if usersConfigFile != "" || groupsConfigFile != "" || orgunitsConfigFile != "" {
-		splittedConfig = true
-	}
-	if splittedConfig == true && configFile != "" {
+	splitConfig = usersConfigFile != "" || groupsConfigFile != "" || orgunitsConfigFile != ""
+
+	if splitConfig == true && configFile != "" {
 		log.Print("⚠ General configuration file specified (-config); cannot manage resources in separated files as well (-users-config/-groups-config/-orgunits-config).\n\n")
 		flag.Usage()
 		os.Exit(1)
-	} else if splittedConfig == false && configFile == "" {
+	} else if splitConfig == false && configFile == "" {
 		// general config file must be present if no splitted ones are specified
 		configFile = os.Getenv("GMAN_CONFIG_FILE")
 		if configFile == "" {
@@ -78,7 +77,7 @@ func main() {
 			flag.Usage()
 			os.Exit(1)
 		}
-	} else if splittedConfig == false && configFile != "" {
+	} else if splitConfig == false && configFile != "" {
 		// open one config file
 		cfg, err := config.LoadFromFile(configFile)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,7 +106,16 @@ func SaveToFile(config *Config, filename string) error {
 	return nil
 }
 
-func (c *Config) Validate() []error {
+// validateEmailFormat is a helper function that checks for existance of '@' and the length of the address
+func validateEmailFormat(email string) bool {
+	if (strings.Contains(email, "@")) && len(email) < 129 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (c *Config) ValidateUsers() []error {
 	var allTheErrors []error
 	re164 := regexp.MustCompile("^\\+[1-9]\\d{1,14}$")
 
@@ -186,6 +195,21 @@ func (c *Config) Validate() []error {
 		userEmails = append(userEmails, user.PrimaryEmail)
 	}
 
+	if allTheErrors != nil {
+		return allTheErrors
+	} else {
+		return nil
+	}
+}
+
+func (c *Config) ValidateGroups() []error {
+	var allTheErrors []error
+
+	// validate organization
+	if c.Organization == "" {
+		allTheErrors = append(allTheErrors, errors.New("no organization configured"))
+	}
+
 	// validate groups
 	groupEmails := []string{}
 	for _, group := range c.Groups {
@@ -237,6 +261,21 @@ func (c *Config) Validate() []error {
 		}
 	}
 
+	if allTheErrors != nil {
+		return allTheErrors
+	} else {
+		return nil
+	}
+}
+
+func (c *Config) ValidateOrgUnits() []error {
+	var allTheErrors []error
+
+	// validate organization
+	if c.Organization == "" {
+		allTheErrors = append(allTheErrors, errors.New("no organization configured"))
+	}
+
 	// validate org_units
 	ouNames := []string{}
 	for _, ou := range c.OrgUnits {
@@ -269,14 +308,5 @@ func (c *Config) Validate() []error {
 		return allTheErrors
 	} else {
 		return nil
-	}
-}
-
-// validateEmailFormat is a helper function that checks for existance of '@' and the length of the address
-func validateEmailFormat(email string) bool {
-	if (strings.Contains(email, "@")) && len(email) < 129 {
-		return true
-	} else {
-		return false
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,11 +108,7 @@ func SaveToFile(config *Config, filename string) error {
 
 // validateEmailFormat is a helper function that checks for existance of '@' and the length of the address
 func validateEmailFormat(email string) bool {
-	if (strings.Contains(email, "@")) && len(email) < 129 {
-		return true
-	} else {
-		return false
-	}
+	return (len(email) < 129 && strings.Contains(email, "@"))
 }
 
 func (c *Config) ValidateUsers() []error {

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -11,7 +11,6 @@ import (
 )
 
 func ExportUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config) error {
-	//log.Println("⇄ Exporting users from GSuite...")
 	// get the users array
 	users, err := glib.GetListOfUsers(*clientService)
 	if err != nil {
@@ -37,7 +36,6 @@ func ExportUsers(ctx context.Context, clientService *admin.Service, licensingSer
 }
 
 func ExportGroups(ctx context.Context, clientService *admin.Service, groupService *groupssettings.Service, cfg *config.Config) error {
-	//log.Println("⇄ Exporting groups from GSuite...")
 	// get the groups array
 	groups, err := glib.GetListOfGroups(clientService)
 	if err != nil {
@@ -70,7 +68,6 @@ func ExportGroups(ctx context.Context, clientService *admin.Service, groupServic
 }
 
 func ExportOrgUnits(ctx context.Context, clientService *admin.Service, cfg *config.Config) error {
-	// log.Println("⇄ Exporting organizational units from GSuite...")
 	// get the users array
 	orgUnits, err := glib.GetListOfOrgUnits(clientService)
 	if err != nil {

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -2,7 +2,6 @@ package export
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/kubermatic-labs/gman/pkg/config"
@@ -11,28 +10,8 @@ import (
 	groupssettings "google.golang.org/api/groupssettings/v1"
 )
 
-func ExportConfiguration(ctx context.Context, organization string, clientService *admin.Service, groupService *groupssettings.Service, licensingService *glib.LicensingService) (*config.Config, error) {
-	cfg := &config.Config{
-		Organization: organization,
-	}
-
-	if err := exportOrgUnits(ctx, clientService, cfg); err != nil {
-		return cfg, fmt.Errorf("org units: %v", err)
-	}
-
-	if err := exportUsers(ctx, clientService, licensingService, cfg); err != nil {
-		return cfg, fmt.Errorf("users: %v", err)
-	}
-
-	if err := exportGroups(ctx, clientService, groupService, cfg); err != nil {
-		return cfg, fmt.Errorf("groups: %v", err)
-	}
-
-	return cfg, nil
-}
-
-func exportUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config) error {
-	log.Println("⇄ Exporting users from GSuite...")
+func ExportUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config) error {
+	//log.Println("⇄ Exporting users from GSuite...")
 	// get the users array
 	users, err := glib.GetListOfUsers(*clientService)
 	if err != nil {
@@ -51,15 +30,14 @@ func exportUsers(ctx context.Context, clientService *admin.Service, licensingSer
 			}
 			usr := glib.CreateConfigUserFromGSuite(u, userLicenses)
 			cfg.Users = append(cfg.Users, usr)
-
 		}
 	}
 
 	return nil
 }
 
-func exportGroups(ctx context.Context, clientService *admin.Service, groupService *groupssettings.Service, cfg *config.Config) error {
-	log.Println("⇄ Exporting groups from GSuite...")
+func ExportGroups(ctx context.Context, clientService *admin.Service, groupService *groupssettings.Service, cfg *config.Config) error {
+	//log.Println("⇄ Exporting groups from GSuite...")
 	// get the groups array
 	groups, err := glib.GetListOfGroups(clientService)
 	if err != nil {
@@ -84,7 +62,6 @@ func exportGroups(ctx context.Context, clientService *admin.Service, groupServic
 			if err != nil {
 				return err
 			}
-
 			cfg.Groups = append(cfg.Groups, thisGroup)
 		}
 	}
@@ -92,8 +69,8 @@ func exportGroups(ctx context.Context, clientService *admin.Service, groupServic
 	return nil
 }
 
-func exportOrgUnits(ctx context.Context, clientService *admin.Service, cfg *config.Config) error {
-	log.Println("⇄ Exporting organizational units from GSuite...")
+func ExportOrgUnits(ctx context.Context, clientService *admin.Service, cfg *config.Config) error {
+	// log.Println("⇄ Exporting organizational units from GSuite...")
 	// get the users array
 	orgUnits, err := glib.GetListOfOrgUnits(clientService)
 	if err != nil {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -12,21 +12,6 @@ import (
 	"google.golang.org/api/groupssettings/v1"
 )
 
-func SyncConfiguration(ctx context.Context, cfg *config.Config, clientService *admin.Service, groupService *groupssettings.Service, licensingService *glib.LicensingService, confirm bool) error {
-
-	if err := SyncOrgUnits(ctx, clientService, cfg, confirm); err != nil {
-		return fmt.Errorf("failed to sync org units: %v", err)
-	}
-	if err := SyncUsers(ctx, clientService, licensingService, cfg, confirm); err != nil {
-		return fmt.Errorf("failed to sync users: %v", err)
-	}
-	if err := SyncGroups(ctx, clientService, groupService, cfg, confirm); err != nil {
-		return fmt.Errorf("failed to sync groups: %v", err)
-	}
-
-	return nil
-}
-
 func SyncUsers(ctx context.Context, clientService *admin.Service, licensingService *glib.LicensingService, cfg *config.Config, confirm bool) error {
 	var (
 		usersToDelete []*admin.User


### PR DESCRIPTION
This PR introduces a possibility to divide the configuration yaml into 3 separated files: 
- users config file (`-users-config` flag), 
- groups config file (`-groups-config` flag), 
- and organizational units config file (`-orgunits-config` flag). 

Gman can still operate on only one file (`-config` flag was kept), but the general functions for export/sync/validation were obsolete, as the main structure had changed.